### PR TITLE
Fix for incorrect prototype of sys_lwmutex_lock

### DIFF
--- a/psl1ght/include/psl1ght/lv2/thread.h
+++ b/psl1ght/include/psl1ght/lv2/thread.h
@@ -9,7 +9,7 @@ s32 sys_ppu_thread_get_id(sys_ppu_thread_t * threadid);
 void sys_ppu_thread_exit(u64 val);
 s32 sys_lwmutex_create(sys_lwmutex_t *lwmutex, const sys_lwmutex_attribute_t *lwmutex_attr);
 void sys_lwmutex_destroy(sys_lwmutex_t *lwmutex);
-s32 sys_lwmutex_lock(sys_lwmutex_t *lwmutex);
+s32 sys_lwmutex_lock(sys_lwmutex_t *lwmutex, u64 timeout_usec);
 void sys_lwmutex_unlock(sys_lwmutex_t *lwmutex);
 
 LV2_SYSCALL lv2ThreadYield() { return Lv2Syscall0(43); }


### PR DESCRIPTION
Oops, it looks like I messed up a little.  The sys_lwmutex_lock function
should have two parameters actually.  It takes a timeout, just like the non-lw
mutices do.
