### PR TITLE
Fix for ld warning when using unitialized thread local data

### DIFF
--- a/psl1ght/linker.x
+++ b/psl1ght/linker.x
@@ -132,7 +132,7 @@ SECTIONS
 		PROVIDE_HIDDEN (__preinit_array_start = .);
 		KEEP (*(.preinit_array))
 		PROVIDE_HIDDEN (__preinit_array_end = .);
-	}
+	} : hdr_data
 	.init_array     : {
 		PROVIDE_HIDDEN (__init_array_start = .);
 		KEEP (*(SORT(.init_array.*)))


### PR DESCRIPTION
Hi.

The linker script had a bug which caused a warning whenever the .tbss section was non-empty.
Apparently the : hdr_tls declaration carried over to subsequent sections, causing them to overlap.
Explicitly putting them in : hdr_data only fixed the problem.
