### PR TITLE
Fixed a missing FD mask for net_get_sockinfo

### DIFF
--- a/psl1ght/include/net/net.h
+++ b/psl1ght/include/net/net.h
@@ -40,7 +40,7 @@ s32* _net_errno_loc(void);
 
 
 s32 net_finalize_network();
-s32 net_get_sockinfo(s32 s, net_sockinfo_t* p, s32 n);
+s32 net_get_sockinfo(s32 socket, net_sockinfo_t* p, s32 n);
 s32 net_initialize_network_ex(net_init_param_t* param);
 s32 net_show_ifconfig();
 s32 net_show_nameserver();

--- a/psl1ght/include/net/net.h
+++ b/psl1ght/include/net/net.h
@@ -27,9 +27,9 @@ typedef struct net_sockinfo {
 	s32 proto;
 	s32 recv_queue_len;
 	s32 send_queue_len;
-	u32 local_adr;
+	struct in_addr local_adr;
 	s32 local_port;
-	u32 remote_adr;
+	struct in_addr remote_adr;
 	s32 remote_port;
 	s32 state;
 } net_sockinfo_t;

--- a/psl1ght/include/sys/socket.h
+++ b/psl1ght/include/sys/socket.h
@@ -117,6 +117,9 @@ int socket_sprx(int domain, int type, int protocol);
 int socketpair_sprx(int domain, int type, int protocol, int socket_vector[2]);
 s32 closesocket_sprx(int socket);
 
+/* sony sprx functions that involve sockets */
+s32 net_get_sockinfo_sprx(s32 socket, net_sockinfo_t* p, s32 n);
+
 /* normal func prototypes */
 int accept(int socket, const struct sockaddr* address, socklen_t* address_len);
 int bind(int socket, const struct sockaddr* address, socklen_t address_len);

--- a/psl1ght/libc-glue-ppu/source/socket.c
+++ b/psl1ght/libc-glue-ppu/source/socket.c
@@ -75,10 +75,13 @@ int closesocket(int socket)
 	return closesocket_sprx(FD(socket));
 }
 
+s32 net_get_sockinfo(s32 socket, net_sockinfo_t* p, s32 n)
+{
+	return net_get_sockinfo_sprx(FD(socket), p, n);
+}
+
 int select(int nfds, fd_set* readfds, fd_set* writefds, fd_set* errorfds, struct timeval* timeout)
 {
 	errno = ENOSYS;
 	return -1;
 }
-
-

--- a/psl1ght/sprx/libnet/exports.h
+++ b/psl1ght/sprx/libnet/exports.h
@@ -37,7 +37,7 @@ EXPORT(net_finalize_network,			0xb68d5625);
 EXPORT(net_free_thread_context,			0xfdb8f926);
 EXPORT(net_get_lib_name_server,			0x1d14d6e4);
 EXPORT(net_get_netemu_test_param,		0x368823c0);
-EXPORT(net_get_sockinfo,				0x3b27c780);
+EXPORT(net_get_sockinfo_sprx,			0x3b27c780);
 EXPORT(net_get_sockinfo_ex,				0xa765d029);
 EXPORT(net_get_test_param,				0xa5a86557);
 EXPORT(net_get_udpp2p_test_param,		0x05bd4438);


### PR DESCRIPTION
The Sony SPRX function net_get_sockinfo was missing proper file descriptor masking, since PSL1GHT uses a bitmask to identify socket vs. file descriptors, this caused issues when calling this function.
