### PR TITLE
lwmutex maintenance

### DIFF
--- a/psl1ght/include/sys/thread.h
+++ b/psl1ght/include/sys/thread.h
@@ -104,6 +104,7 @@ void sys_ppu_thread_exit(u64 val);
 s32 sys_lwmutex_create(sys_lwmutex_t *lwmutex, const sys_lwmutex_attribute_t *lwmutex_attr);
 void sys_lwmutex_destroy(sys_lwmutex_t *lwmutex);
 s32 sys_lwmutex_lock(sys_lwmutex_t *lwmutex, u64 timeout_usec);
+s32 sys_lwmutex_trylock(sys_lwmutex_t *lwmutex);
 void sys_lwmutex_unlock(sys_lwmutex_t *lwmutex);
 
 EXTERN_END

--- a/psl1ght/include/sys/thread.h
+++ b/psl1ght/include/sys/thread.h
@@ -101,9 +101,9 @@ s32 sys_ppu_thread_create(sys_ppu_thread_t * threadid, void (*entry) (u64 arg), 
 s32 sys_ppu_thread_get_id(sys_ppu_thread_t * threadid);
 void sys_ppu_thread_exit(u64 val);
 s32 sys_lwmutex_create(sys_lwmutex_t *lwmutex, const sys_lwmutex_attribute_t *lwmutex_attr);
-void sys_lwmutex_destroy(sys_lwmutex_t *lwmutex);
+s32 sys_lwmutex_destroy(sys_lwmutex_t *lwmutex);
 s32 sys_lwmutex_lock(sys_lwmutex_t *lwmutex, u64 timeout_usec);
 s32 sys_lwmutex_trylock(sys_lwmutex_t *lwmutex);
-void sys_lwmutex_unlock(sys_lwmutex_t *lwmutex);
+s32 sys_lwmutex_unlock(sys_lwmutex_t *lwmutex);
 
 EXTERN_END

--- a/psl1ght/include/sys/thread.h
+++ b/psl1ght/include/sys/thread.h
@@ -17,8 +17,7 @@ typedef struct sys_ppu_thread_stack_t {
 }sys_ppu_thread_stack_t;
 
 typedef struct sys_lwmutex_t {
-	u32 owner;
-	u32 waiter;
+	u64 lock_var;
 	u32 attribute;
 	u32 recursive_count;
 	u32 sleep_queue;

--- a/psl1ght/sprx/liblv2/exports.h
+++ b/psl1ght/sprx/liblv2/exports.h
@@ -18,6 +18,7 @@ EXPORT(sys_ppu_thread_unregister_atexit, 0xac6fc404);
 EXPORT(sys_lwmutex_create, 0x2f85c0ef);
 EXPORT(sys_lwmutex_destroy, 0xc3476d0c);
 EXPORT(sys_lwmutex_lock, 0x1573dc3f);
+EXPORT(sys_lwmutex_trylock, 0xaeb78725);
 EXPORT(sys_lwmutex_unlock, 0x1bc200f4);
 EXPORT(sys_initialize_tls, 0x744680a2);
 EXPORT(sys_time_get_system_time, 0x8461e528);


### PR DESCRIPTION
Hi.

These commits fix three outstanding issues with lwmutices:
- Add the missing function sys_lwmutex_trylock() which never blocks
- Give the lwmutex structure the appropriate alignment (important when allocating
  mutices statically)
- Give the correct return type to sys_lwmutex_unlock() and sys_lwmutex_destroy()
  
  // Marcus
