### PR TITLE
Various fixes and improvements to cgcomp

### DIFF
--- a/tools/cgcomp/include/compilerfp.h
+++ b/tools/cgcomp/include/compilerfp.h
@@ -35,6 +35,8 @@ private:
 	void emit_dst(struct nvfx_reg *dst,bool *have_const);
 	void emit_src(s32 pos,struct nvfx_src *src,bool *have_const);
 	void emit_brk(struct nvfx_insn *insn);
+	void emit_rep(struct nvfx_insn *insn);
+	void fixup_rep();
 
 	void grow_insns(int count);
 
@@ -67,6 +69,7 @@ private:
 
 	std::list<param> m_lImmData;
 	std::list<struct fragment_program_data> m_lConstData;
+	std::stack<int> m_repStack;
 };
 
 #endif

--- a/tools/cgcomp/include/compilerfp.h
+++ b/tools/cgcomp/include/compilerfp.h
@@ -34,6 +34,7 @@ private:
 	void emit_insn(u8 op,struct nvfx_insn *insn);
 	void emit_dst(struct nvfx_reg *dst,bool *have_const);
 	void emit_src(s32 pos,struct nvfx_src *src,bool *have_const);
+	void emit_brk(struct nvfx_insn *insn);
 
 	void grow_insns(int count);
 

--- a/tools/cgcomp/include/nvfx_shader.h
+++ b/tools/cgcomp/include/nvfx_shader.h
@@ -516,6 +516,8 @@ enum nvfx_opcode
    OPCODE_X2D,       /*                            X             */
    OPCODE_XOR,       /*                                          */
    OPCODE_XPD,       /*   X        X                         X   */
+   OPCODE_BGNREP,    /*                            2             */
+   OPCODE_ENDREP,    /*                            2             */
    MAX_OPCODE
 };
 

--- a/tools/cgcomp/include/parser.h
+++ b/tools/cgcomp/include/parser.h
@@ -2,6 +2,7 @@
 #define __PARSER_H__
 
 #include <list>
+#include <stack>
 #include <string>
 #include <sstream>
 

--- a/tools/cgcomp/include/parser.h
+++ b/tools/cgcomp/include/parser.h
@@ -81,6 +81,7 @@ protected:
 	const char* ParseTempReg(const char *token,s32 *idx);
 	const char* ConvertCond(const char *token,struct nvfx_insn *insn);
 	const char* ParseMaskedDstRegExt(const char *token,struct nvfx_insn *insn);
+	const char* ParseCond(const char *token,struct nvfx_insn *insn);
 
 	s32 GetParamType(const char *param_str);
 	virtual s32 ConvertInputReg(const char *token) = 0;

--- a/tools/cgcomp/source/compilerfp.cpp
+++ b/tools/cgcomp/source/compilerfp.cpp
@@ -190,6 +190,12 @@ void CCompilerFP::Compile(CParser *pParser)
 			case OPCODE_TXP:
 				emit_insn(NVFX_FP_OP_OPCODE_TXP,insn);
 				break;
+			case OPCODE_BGNREP:
+				emit_rep(insn);
+				break;
+			case OPCODE_ENDREP:
+				fixup_rep();
+				break;
 			case OPCODE_END:
 				if(m_nInstructions) m_pInstructions[m_nCurInstruction].data[0] |= NVFX_FP_OP_PROGRAM_END;
 				else {
@@ -357,6 +363,55 @@ void CCompilerFP::emit_brk(struct nvfx_insn *insn)
 			  (insn->cc_swz[1] << NVFX_FP_OP_COND_SWZ_Y_SHIFT) |
 		      (insn->cc_swz[2] << NVFX_FP_OP_COND_SWZ_Z_SHIFT) |
 		      (insn->cc_swz[3] << NVFX_FP_OP_COND_SWZ_W_SHIFT));
+}
+
+void CCompilerFP::emit_rep(struct nvfx_insn *insn)
+{
+	u32 *hw;
+	int count;
+
+	m_nCurInstruction = m_nInstructions;
+	grow_insns(1);
+	memset(&m_pInstructions[m_nCurInstruction],0,sizeof(struct fragment_program_exec));
+
+	hw = m_pInstructions[m_nCurInstruction].data;
+
+	param fpd = GetImmData(insn->src[0].reg.index);
+
+	if (insn->src[0].reg.type != NVFXSR_IMM ||
+	    (*fpd.values)[0] < 0.0 || (*fpd.values)[0] > 255.0) {
+		fprintf(stderr,"Input to REP must be immediate number 0-255\n");
+		exit(EXIT_FAILURE);
+	}
+	    
+	count = (int)(*fpd.values)[0];
+
+	hw[0] |= (NV40_FP_OP_BRA_OPCODE_REP << NVFX_FP_OP_OPCODE_SHIFT);
+	hw[0] |= NV40_FP_OP_OUT_NONE;
+	hw[0] |= NVFX_FP_PRECISION_FP16 <<  NVFX_FP_OP_PRECISION_SHIFT;
+	hw[2] |= NV40_FP_OP_OPCODE_IS_BRANCH;
+	hw[2] |= (count<<NV40_FP_OP_REP_COUNT1_SHIFT)|
+	  (count<<NV40_FP_OP_REP_COUNT2_SHIFT)|
+	  (count<<NV40_FP_OP_REP_COUNT3_SHIFT);
+
+	hw[1] |= (insn->cc_cond << NVFX_FP_OP_COND_SHIFT);
+	hw[1] |= ((insn->cc_swz[0] << NVFX_FP_OP_COND_SWZ_X_SHIFT) |
+			  (insn->cc_swz[1] << NVFX_FP_OP_COND_SWZ_Y_SHIFT) |
+		      (insn->cc_swz[2] << NVFX_FP_OP_COND_SWZ_Z_SHIFT) |
+		      (insn->cc_swz[3] << NVFX_FP_OP_COND_SWZ_W_SHIFT));
+
+	m_repStack.push(m_nCurInstruction);
+}
+
+void CCompilerFP::fixup_rep()
+{
+	u32 *hw;
+
+	hw = m_pInstructions[m_repStack.top()].data;
+
+	hw[3] |= m_nInstructions * 4;
+
+	m_repStack.pop();
 }
 
 struct nvfx_reg CCompilerFP::temp()

--- a/tools/cgcomp/source/compilerfp.cpp
+++ b/tools/cgcomp/source/compilerfp.cpp
@@ -89,6 +89,9 @@ void CCompilerFP::Compile(CParser *pParser)
 			case OPCODE_ADD:
 				emit_insn(NVFX_FP_OP_OPCODE_ADD,insn);
 				break;
+			case OPCODE_BRK:
+				emit_brk(insn);
+				break;
 			case OPCODE_COS:
 				emit_insn(NVFX_FP_OP_OPCODE_COS,insn);
 				break;
@@ -333,6 +336,27 @@ void CCompilerFP::emit_src(s32 pos,struct nvfx_src *src,bool *have_const)
 	       (src->swz[3] << NVFX_FP_REG_SWZ_W_SHIFT));
 
 	hw[pos + 1] |= sr;
+}
+
+void CCompilerFP::emit_brk(struct nvfx_insn *insn)
+{
+	u32 *hw;
+
+	m_nCurInstruction = m_nInstructions;
+	grow_insns(1);
+	memset(&m_pInstructions[m_nCurInstruction],0,sizeof(struct fragment_program_exec));
+
+	hw = m_pInstructions[m_nCurInstruction].data;
+
+	hw[0] |= (NV40_FP_OP_BRA_OPCODE_BRK << NVFX_FP_OP_OPCODE_SHIFT);
+	hw[0] |= NV40_FP_OP_OUT_NONE;
+	hw[2] |= NV40_FP_OP_OPCODE_IS_BRANCH;
+
+	hw[1] |= (insn->cc_cond << NVFX_FP_OP_COND_SHIFT);
+	hw[1] |= ((insn->cc_swz[0] << NVFX_FP_OP_COND_SWZ_X_SHIFT) |
+			  (insn->cc_swz[1] << NVFX_FP_OP_COND_SWZ_Y_SHIFT) |
+		      (insn->cc_swz[2] << NVFX_FP_OP_COND_SWZ_Z_SHIFT) |
+		      (insn->cc_swz[3] << NVFX_FP_OP_COND_SWZ_W_SHIFT));
 }
 
 struct nvfx_reg CCompilerFP::temp()

--- a/tools/cgcomp/source/fpparser.cpp
+++ b/tools/cgcomp/source/fpparser.cpp
@@ -89,6 +89,8 @@ struct _opcode
    { "UP4UB", OPCODE_UP4UB, INPUT_1S, OUTPUT_V,            _C | _S },
    { "X2D", OPCODE_X2D, INPUT_3V, OUTPUT_V, _R | _H |      _C | _S },
    { "PRINT", OPCODE_PRINT, INPUT_1V_S, OUTPUT_NONE, 0             },
+   { "REP", OPCODE_BGNREP, INPUT_1V, OUTPUT_NONE, 0                },
+   { "ENDREP", OPCODE_ENDREP, INPUT_NONE, OUTPUT_NONE, 0           },
    //
    { "END", OPCODE_END,0,0,0 },
    { NULL, (enum nvfx_opcode) -1, 0, 0, 0 }

--- a/tools/cgcomp/source/fpparser.cpp
+++ b/tools/cgcomp/source/fpparser.cpp
@@ -505,7 +505,8 @@ void CFPParser::ParseMaskedDstReg(const char *token,struct nvfx_insn *insn)
 		insn->dst.index = idx;
 		insn->dst.is_fp16 = (token[0]=='H');
 	} else if(token[0]=='o' && token[1]=='[') {
-		token = ParseOutputReg(token,&idx);
+		token = ParseOutputReg(&token[2],&idx);
+		token++;
 
 		insn->dst.type = NVFXSR_OUTPUT;
 		insn->dst.index = idx;

--- a/tools/cgcomp/source/fpparser.cpp
+++ b/tools/cgcomp/source/fpparser.cpp
@@ -230,17 +230,18 @@ void CFPParser::ParseInstruction(struct nvfx_insn *insn,opcode *opc,const char *
 		ParseMaskedDstReg(token,insn);
 	}
 
-	if(opc->inputs==INPUT_1V) {
+	if(opc->outputs!=OUTPUT_NONE && opc->inputs!=INPUT_NONE) {
 		token = SkipSpaces(strtok(NULL,","));
+	}
+
+	if(opc->inputs==INPUT_1V) {
 		ParseVectorSrc(token,&insn->src[0]);
 	} else if(opc->inputs==INPUT_2V) {
-		token = SkipSpaces(strtok(NULL,","));
 		ParseVectorSrc(token,&insn->src[0]);
 
 		token = SkipSpaces(strtok(NULL,","));
 		ParseVectorSrc(token,&insn->src[1]);
 	} else if(opc->inputs==INPUT_3V) {
-		token = SkipSpaces(strtok(NULL,","));
 		ParseVectorSrc(token,&insn->src[0]);
 
 		token = SkipSpaces(strtok(NULL,","));
@@ -249,10 +250,8 @@ void CFPParser::ParseInstruction(struct nvfx_insn *insn,opcode *opc,const char *
 		token = SkipSpaces(strtok(NULL,","));
 		ParseVectorSrc(token,&insn->src[2]);
 	} else if(opc->inputs==INPUT_1S) {
-		token = SkipSpaces(strtok(NULL,","));
 		ParseScalarSrc(token,&insn->src[0]);
 	} else if(opc->inputs==INPUT_2S) {
-		token = SkipSpaces(strtok(NULL,","));
 		ParseScalarSrc(token,&insn->src[0]);
 
 		token = SkipSpaces(strtok(NULL,","));
@@ -260,7 +259,6 @@ void CFPParser::ParseInstruction(struct nvfx_insn *insn,opcode *opc,const char *
 	} else if(opc->inputs==INPUT_1V_T) {
 		u8 unit,target;
 
-		token = SkipSpaces(strtok(NULL,","));
 		ParseVectorSrc(token,&insn->src[0]);
 
 		token = SkipSpaces(strtok(NULL,","));
@@ -273,7 +271,6 @@ void CFPParser::ParseInstruction(struct nvfx_insn *insn,opcode *opc,const char *
 	} else if(opc->inputs==INPUT_3V_T) {
 		u8 unit,target;
 
-		token = SkipSpaces(strtok(NULL,","));
 		ParseVectorSrc(token,&insn->src[0]);
 
 		token = SkipSpaces(strtok(NULL,","));

--- a/tools/cgcomp/source/fpparser.cpp
+++ b/tools/cgcomp/source/fpparser.cpp
@@ -43,6 +43,7 @@ struct _opcode
 	u32 suffixes;
 } fp_opcodes[] = {
    { "ADD", OPCODE_ADD, INPUT_2V, OUTPUT_V, _R | _H | _X | _C | _S },
+   { "BRK", OPCODE_BRK, INPUT_CC, OUTPUT_NONE, 0                   },
    { "COS", OPCODE_COS, INPUT_1S, OUTPUT_S, _R | _H |      _C | _S },
    { "DDX", OPCODE_DDX, INPUT_1V, OUTPUT_V, _R | _H |      _C | _S },
    { "DDY", OPCODE_DDY, INPUT_1V, OUTPUT_V, _R | _H |      _C | _S },
@@ -286,6 +287,8 @@ void CFPParser::ParseInstruction(struct nvfx_insn *insn,opcode *opc,const char *
 		ParseTextureTarget(token,&target);
 
 		insn->unit = unit;
+	} else if(opc->inputs==INPUT_CC) {
+		ParseCond(token,insn);
 	}
 }
 

--- a/tools/cgcomp/source/main.cpp
+++ b/tools/cgcomp/source/main.cpp
@@ -420,12 +420,13 @@ int compileFP()
 int main(int argc,char *argv[])
 {
 	int ret = 0;
-	if(!InitCompiler()) {
-        fprintf(stderr, "Unable to load Cg, aborting.\n");
-        return EXIT_FAILURE;
-    }
 
 	readoptions(&Options,argc,argv);
+	
+	if(Options.gen_asm!=true && !InitCompiler()) {
+	  fprintf(stderr, "Unable to load Cg, aborting.\n");
+	  return EXIT_FAILURE;
+	}
 
 	switch(Options.prog_type) {
 		case PROG_TYPE_VP:

--- a/tools/cgcomp/source/main.cpp
+++ b/tools/cgcomp/source/main.cpp
@@ -12,8 +12,13 @@
 #define PROG_TYPE_VP			1
 #define PROG_TYPE_FP			2
 
+#ifdef __BIG_ENDIAN__
+#define SWAP16(v) (v)
+#define SWAP32(v) (v)
+#else
 #define SWAP16(v) ((v)>>8)|((v)<<8)
 #define SWAP32(v) ((v)>>24)|((v)<<24)|(((v)&0xFF00)<<8)|(((v)&0xFF0000)>>8)
+#endif
 
 struct _options
 {

--- a/tools/cgcomp/source/parser.cpp
+++ b/tools/cgcomp/source/parser.cpp
@@ -213,34 +213,40 @@ const char* CParser::ParseMaskedDstRegExt(const char *token,struct nvfx_insn *in
 	token = ParseOutputMask(token,&insn->mask);
 	if(token && *token!='\0') {
 		if(token[0]=='(') {
-			token = ConvertCond(&token[1],insn);
-			if(token[0]=='.') {
-				s32 k = 0;
-				
-				token++;
-
-				insn->cc_swz[0] = insn->cc_swz[1] = insn->cc_swz[2] = insn->cc_swz[3] = 0;
-				for(k=0;token[k] && token[k]!=')' && k<4;k++) {
-					if(token[k]=='x')
-						insn->cc_swz[k] = NVFX_SWZ_X;
-					else if(token[k]=='y')
-						insn->cc_swz[k] = NVFX_SWZ_Y;
-					else if(token[k]=='z')
-						insn->cc_swz[k] = NVFX_SWZ_Z;
-					else if(token[k]=='w')
-						insn->cc_swz[k] = NVFX_SWZ_W;
-				}
-				if(k && k<4) {
-					u8 lastswz = insn->cc_swz[k - 1];
-					while(k<4) {
-						insn->cc_swz[k] = lastswz;
-						k++;
-					}
-				}
-				token += k;
-			}
+			token = ParseCond(&token[1],insn);
 			token++;
 		}
+	}
+	return token;
+}
+
+const char* CParser::ParseCond(const char *token,struct nvfx_insn *insn)
+{
+	token = ConvertCond(token,insn);
+	if(token[0]=='.') {
+		s32 k = 0;
+		
+		token++;
+		
+		insn->cc_swz[0] = insn->cc_swz[1] = insn->cc_swz[2] = insn->cc_swz[3] = 0;
+		for(k=0;token[k] && token[k]!=')' && k<4;k++) {
+			if(token[k]=='x')
+				insn->cc_swz[k] = NVFX_SWZ_X;
+			else if(token[k]=='y')
+				insn->cc_swz[k] = NVFX_SWZ_Y;
+			else if(token[k]=='z')
+				insn->cc_swz[k] = NVFX_SWZ_Z;
+			else if(token[k]=='w')
+				insn->cc_swz[k] = NVFX_SWZ_W;
+		}
+		if(k && k<4) {
+			u8 lastswz = insn->cc_swz[k - 1];
+			while(k<4) {
+				insn->cc_swz[k] = lastswz;
+				k++;
+			}
+		}
+		token += k;
 	}
 	return token;
 }


### PR DESCRIPTION
cgcomp does not actually use libCg.so when the -a option is specified, so it makes no sense to require it.
