### PR TITLE
Fix broken RSX samples

### DIFF
--- a/samples/video/rsxTest/include/nv_shaders.h
+++ b/samples/video/rsxTest/include/nv_shaders.h
@@ -21,7 +21,7 @@ static realityVertexProgram_old nv40_vp = {
  * NV30/NV40/G70 fragment shaders
  */
 
-static realityFragmentProgram nv30_fp = {
+static realityFragmentProgram_old nv30_fp = {
 .num_regs = 2,
 .size = (2*4),
 .data = {

--- a/samples/video/rsxTest/source/main.c
+++ b/samples/video/rsxTest/source/main.c
@@ -62,7 +62,7 @@ void drawFrame(int buffer, long frame) {
 
 	// Load shaders, because the rsx won't do anything without them.
 	realityLoadVertexProgram_old(context, &nv40_vp);
-	realityLoadFragmentProgram(context, &nv30_fp); 
+	realityLoadFragmentProgram_old(context, &nv30_fp); 
 
 	// Load texture
 	load_tex(0, tx_offset, dice.width, dice.height, dice.width*4,  NV40_3D_TEX_FORMAT_FORMAT_A8R8G8B8, 1);
@@ -125,7 +125,7 @@ s32 main(s32 argc, const char* argv[])
 	// install fragment shader in rsx memory
 	u32 *frag_mem = rsxMemAlign(256, 256);
 	printf("frag_mem = 0x%08lx\n", (u64) frag_mem);
-	realityInstallFragmentProgram(context, &nv30_fp, frag_mem);
+	realityInstallFragmentProgram_old(context, &nv30_fp, frag_mem);
 
 	long frame = 0; // To keep track of how many frames we have rendered.
 	

--- a/samples/video/rsxTestVP/include/nv_shaders.h
+++ b/samples/video/rsxTestVP/include/nv_shaders.h
@@ -8,7 +8,7 @@
  * NV30/NV40/G70 fragment shaders
  */
 
-static realityFragmentProgram nv30_fp = {
+static realityFragmentProgram_old nv30_fp = {
 .num_regs = 2,
 .size = (2*4),
 .data = {

--- a/samples/video/rsxTestVP/source/main.c
+++ b/samples/video/rsxTestVP/source/main.c
@@ -214,7 +214,7 @@ void drawFrame(int buffer, long frame)
 
 	// Load shaders, because the rsx won't do anything without them.
 	realityLoadVertexProgram(context, (realityVertexProgram*)vshader_bin);
-	realityLoadFragmentProgram(context, &nv30_fp); 
+	realityLoadFragmentProgram_old(context, &nv30_fp); 
 
 	//Pass the matrix to the shader
 	realitySetVertexProgramConstant4fBlock(context,matrixParam,4,(float*)(matrix.data));
@@ -260,7 +260,7 @@ s32 main(s32 argc, const char* argv[])
 	// install fragment shader in rsx memory
 	u32 *frag_mem = rsxMemAlign(256, 256);
 	printf("frag_mem = 0x%08lx\n", (u64) frag_mem);
-	realityInstallFragmentProgram(context, &nv30_fp, frag_mem);
+	realityInstallFragmentProgram_old(context, &nv30_fp, frag_mem);
 
 	//Transfer the vertex buffer to RSX memory (main memory mapping is not supported yet)
 	VertexBufferRSX = rsxMemAlign(64,4*sizeof(struct _Vertex));


### PR DESCRIPTION
The fragment program functions and types now have an "_old" tacked on, which broke the compilation of the RSX samples.  Fixed this by adding the _old suffix to the sample code.
