### PR TITLE
SPU sample cleanups

### DIFF
--- a/samples/spu/spuchain/source/main.c
+++ b/samples/spu/spuchain/source/main.c
@@ -34,9 +34,6 @@
 int main(int argc, const char* argv[])
 {
 	sysSpuImage image;
-	u32 entry = 0;
-	u32 segmentcount = 0;
-	sysSpuSegment* segments;
 	u32 group_id;
 	Lv2SpuThreadAttributes attr = { ptr2ea("mythread"), 8+1, LV2_SPU_THREAD_ATTRIBUTE_NONE };
 	Lv2SpuThreadGroupAttributes grpattr = { 7+1, ptr2ea("mygroup"), 0, 0 };
@@ -48,17 +45,6 @@ int main(int argc, const char* argv[])
 
 	printf("Initializing 6 SPUs... ");
 	printf("%08x\n", lv2SpuInitialize(6, 0));
-
-	printf("Getting ELF information... ");
-	printf("%08x\n", sysSpuElfGetInformation(spu_bin, &entry, &segmentcount));
-	printf("\tEntry Point: %08x\n\tSegment Count: %08x\n", entry, segmentcount);
-
-	size_t segmentsize = sizeof(sysSpuSegment) * segmentcount;
-	segments = (sysSpuSegment*)malloc(segmentsize);
-	memset(segments, 0, segmentsize);
-
-	printf("Getting ELF segments... ");
-	printf("%08x\n", sysSpuElfGetSegments(spu_bin, segments, segmentcount));
 
 	printf("Loading ELF image... ");
 	printf("%08x\n", sysSpuImageImport(&image, spu_bin, 0));

--- a/samples/spu/spudma/source/main.c
+++ b/samples/spu/spudma/source/main.c
@@ -13,9 +13,6 @@
 int main(int argc, const char* argv[])
 {
 	sysSpuImage image;
-	u32 entry = 0;
-	u32 segmentcount = 0;
-	sysSpuSegment* segments;
 	u32 thread_id;
 	u32 group_id;
 	Lv2SpuThreadAttributes attr = { ptr2ea("mythread"), 8+1, LV2_SPU_THREAD_ATTRIBUTE_NONE };
@@ -28,17 +25,6 @@ int main(int argc, const char* argv[])
 
 	printf("Initializing 6 SPUs... ");
 	printf("%08x\n", lv2SpuInitialize(6, 0));
-
-	printf("Getting ELF information... ");
-	printf("%08x\n", sysSpuElfGetInformation(spu_bin, &entry, &segmentcount));
-	printf("\tEntry Point: %08x\n\tSegment Count: %08x\n", entry, segmentcount);
-
-	size_t segmentsize = sizeof(sysSpuSegment) * segmentcount;
-	segments = (sysSpuSegment*)malloc(segmentsize);
-	memset(segments, 0, segmentsize);
-
-	printf("Getting ELF segments... ");
-	printf("%08x\n", sysSpuElfGetSegments(spu_bin, segments, segmentcount));
 
 	printf("Loading ELF image... ");
 	printf("%08x\n", sysSpuImageImport(&image, spu_bin, 0));

--- a/samples/spu/spuparallel/source/main.c
+++ b/samples/spu/spuparallel/source/main.c
@@ -42,9 +42,6 @@
 int main(int argc, const char* argv[])
 {
 	sysSpuImage image;
-	u32 entry = 0;
-	u32 segmentcount = 0;
-	sysSpuSegment* segments;
 	u32 group_id;
 	Lv2SpuThreadAttributes attr = { ptr2ea("mythread"), 8+1, LV2_SPU_THREAD_ATTRIBUTE_NONE };
 	Lv2SpuThreadGroupAttributes grpattr = { 7+1, ptr2ea("mygroup"), 0, 0 };
@@ -56,17 +53,6 @@ int main(int argc, const char* argv[])
 
 	printf("Initializing 6 SPUs... ");
 	printf("%08x\n", lv2SpuInitialize(6, 0));
-
-	printf("Getting ELF information... ");
-	printf("%08x\n", sysSpuElfGetInformation(spu_bin, &entry, &segmentcount));
-	printf("\tEntry Point: %08x\n\tSegment Count: %08x\n", entry, segmentcount);
-
-	size_t segmentsize = sizeof(sysSpuSegment) * segmentcount;
-	segments = (sysSpuSegment*)malloc(segmentsize);
-	memset(segments, 0, segmentsize);
-
-	printf("Getting ELF segments... ");
-	printf("%08x\n", sysSpuElfGetSegments(spu_bin, segments, segmentcount));
 
 	printf("Loading ELF image... ");
 	printf("%08x\n", sysSpuImageImport(&image, spu_bin, 0));

--- a/samples/spu/sputest/source/main.c
+++ b/samples/spu/sputest/source/main.c
@@ -5,6 +5,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <malloc.h>
 
 #include "spu.bin.h"
 
@@ -26,7 +27,7 @@ int main(int argc, const char* argv[])
 	printf("\tEntry Point: %08x\n\tSegment Count: %08x\n", entry, segmentcount);
 
 	size_t segmentsize = sizeof(sysSpuSegment) * segmentcount;
-	segments = (sysSpuSegment*)malloc(segmentsize);
+	segments = (sysSpuSegment*)memalign(128, segmentsize);
 	memset(segments, 0, segmentsize);
 
 	printf("Getting ELF segments... ");

--- a/samples/spu/sputest/source/main.c
+++ b/samples/spu/sputest/source/main.c
@@ -5,7 +5,6 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <malloc.h>
 
 #include "spu.bin.h"
 
@@ -13,25 +12,11 @@ int main(int argc, const char* argv[])
 {
 	u32 spu = 0;
 	sysSpuImage image;
-	u32 entry = 0;
-	u32 segmentcount = 0;
-	sysSpuSegment* segments;
 
 	printf("Initializing 6 SPUs... ");
 	printf("%08x\n", lv2SpuInitialize(6, 5));
 	printf("Initializing raw SPU... ");
 	printf("%08x\n", lv2SpuRawCreate(&spu, NULL));
-
-	printf("Getting ELF information... ");
-	printf("%08x\n", sysSpuElfGetInformation(spu_bin, &entry, &segmentcount));
-	printf("\tEntry Point: %08x\n\tSegment Count: %08x\n", entry, segmentcount);
-
-	size_t segmentsize = sizeof(sysSpuSegment) * segmentcount;
-	segments = (sysSpuSegment*)memalign(128, segmentsize);
-	memset(segments, 0, segmentsize);
-
-	printf("Getting ELF segments... ");
-	printf("%08x\n", sysSpuElfGetSegments(spu_bin, segments, segmentcount));
 
 	printf("Loading ELF image... ");
 	printf("%08x\n", sysSpuImageImport(&image, spu_bin, 0));

--- a/samples/spu/sputhread/source/main.c
+++ b/samples/spu/sputhread/source/main.c
@@ -13,9 +13,6 @@
 int main(int argc, const char* argv[])
 {
 	sysSpuImage image;
-	u32 entry = 0;
-	u32 segmentcount = 0;
-	sysSpuSegment* segments;
 	u32 thread_id;
 	u32 group_id;
 	Lv2SpuThreadAttributes attr = { ptr2ea("mythread"), 8+1, LV2_SPU_THREAD_ATTRIBUTE_NONE };
@@ -27,17 +24,6 @@ int main(int argc, const char* argv[])
 
 	printf("Initializing 6 SPUs... ");
 	printf("%08x\n", lv2SpuInitialize(6, 0));
-
-	printf("Getting ELF information... ");
-	printf("%08x\n", sysSpuElfGetInformation(spu_bin, &entry, &segmentcount));
-	printf("\tEntry Point: %08x\n\tSegment Count: %08x\n", entry, segmentcount);
-
-	size_t segmentsize = sizeof(sysSpuSegment) * segmentcount;
-	segments = (sysSpuSegment*)malloc(segmentsize);
-	memset(segments, 0, segmentsize);
-
-	printf("Getting ELF segments... ");
-	printf("%08x\n", sysSpuElfGetSegments(spu_bin, segments, segmentcount));
 
 	printf("Loading ELF image... ");
 	printf("%08x\n", sysSpuImageImport(&image, spu_bin, 0));


### PR DESCRIPTION
skagkur discovered that memory-alignment of segments is necessary to allow the access of PPU malloc'ed arrays from SPU via DMA. this required a fix in sputest (raw SPU management).

Moreover, he discovered segment initialization is not necessary at all when dealing with SPU threads. Thus I removed the useless parts of code in the SPU thread samples.
